### PR TITLE
Prevent app from crashing when redux devtools is not installed

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,10 +3,9 @@ import { createStore, applyMiddleware, compose } from "redux";
 import ReduxThunk from "redux-thunk";
 import reducer from "./rootReducer";
 
-const devTools =
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__();
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const enhancer = compose(applyMiddleware(ReduxThunk), devTools);
+const enhancer = composeEnhancers(applyMiddleware(ReduxThunk));
 
 const store = createStore(reducer, enhancer);
 


### PR DESCRIPTION
# What this pullrequest does

- There was an issue that crashed the app on startup if redux devtools was not installed in your browser
- fix: use  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ when other middelware are applied as well (reduxThunk in this case)

For the curious, here are the docs:
https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup